### PR TITLE
Add Trove Classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,15 @@ setup(
     keywords = ["short", "id", "uuid", "shortid", "tinyid"],
     packages=["shortid"],
     license="MIT",
-    classifiers=[],
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
 )


### PR DESCRIPTION
In your setup.py file you should have the proper trove classifier specifying what versions of Python you support. Ideally you should also specify each major/minor version of Python that you do support, e.g. Programming Language :: Python :: 2.7.

There are potentially many others you can categorize your module with 
https://pypi.python.org/pypi?%3Aaction=list_classifiers